### PR TITLE
Fix breaking other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,8 @@ module.exports = class ReverseImageSearch extends Plugin {
             }
             return res;
         });
+
+        mdl.default.displayName = 'MessageContextMenu';
     }
 
     pluginWillUnload() {


### PR DESCRIPTION
If you not reset the displayName other plugins that user the same context break