### PR TITLE
Add ImgOps to providers.json

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -31,5 +31,13 @@
         "name": "Karmadecay",
         "domain": "http://karmadecay.com/search?q=%%"
     },
-    { "name": "IQDB", "domain": "https://iqdb.org/?url=%%" }
+    {
+        "name": "IQDB",
+        "domain": "https://iqdb.org/?url=%%"
+    },
+    {
+        "name": "ImgOps",
+        "domain": "https://imgops.com/%%",
+        "default": true
+    }
 ]


### PR DESCRIPTION
ImgOps, while not specifically a Reverse Image Search engine, has not only ~14 different RIS links, but also a massive amount of tools that anyone looking for an image could use.